### PR TITLE
feat: Add High Resolution Vehicle Distance (VDHR), Tachograph (TCO1) and local time offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ let timedate = j1939::spn::TimeDate {
     hour: 10,
     minute: 1,
     second: 58,
+    local_hour_offset: Some(0),
+    local_minute_offset: Some(0),
 };
 
 let id = j1939::IdBuilder::from_pgn(j1939::PGN::TimeDate)

--- a/examples/j1939decode.rs
+++ b/examples/j1939decode.rs
@@ -50,6 +50,9 @@ fn decode_data(pgn: PGN, data: &[u8]) {
         PGN::VehicleDistance => {
             println!("  {}", VehicleDistanceMessage::from_pdu(data));
         }
+        PGN::HighResolutionVehicleDistance => {
+            println!("  {}", HighResolutionVehicleDistanceMessage::from_pdu(data));
+        }
         PGN::FanDrive => {
             println!("  {}", FanDriveMessage::from_pdu(data));
         }
@@ -76,6 +79,9 @@ fn decode_data(pgn: PGN, data: &[u8]) {
         }
         PGN::TANKInformation1 => {
             println!("  {}", TankInformation1Message::from_pdu(data));
+        }
+        PGN::Tachograph => {
+            println!("  {}", TachographMessage::from_pdu(data));
         }
         PGN::PowerTakeoffInformation => {
             println!("  {}", PowerTakeoffInformationMessage::from_pdu(data));

--- a/src/pgn.rs
+++ b/src/pgn.rs
@@ -151,6 +151,8 @@ pub enum PGN {
     WaterInFuelIndicator,
     /// ACKM - Acknowledgment Message.
     AcknowledgmentMessage,
+    /// RESET - Reset.
+    Reset,
     /// CI - Component Identification.
     ComponentIdentification,
     /// VI - Vehicle Identification.
@@ -205,6 +207,7 @@ impl From<u32> for PGN {
             49_152 => PGN::ProprietarilyConfigurableMessage16,
             51_456 => PGN::Request2,
             51_712 => PGN::Transfer,
+            56_832 => PGN::Reset,
             59_392 => PGN::AcknowledgmentMessage,
             59_904 => PGN::Request,
             60_160 => PGN::TransportProtocolDataTransfer,
@@ -290,6 +293,7 @@ impl From<PGN> for u32 {
             PGN::ProprietarilyConfigurableMessage16 => 49_152,
             PGN::Request2 => 51_456,
             PGN::Transfer => 51_712,
+            PGN::Reset => 56_832,
             PGN::AcknowledgmentMessage => 59_392,
             PGN::Request => 59_904,
             PGN::TransportProtocolDataTransfer => 60_160,

--- a/src/pgn.rs
+++ b/src/pgn.rs
@@ -47,8 +47,8 @@ pub enum PGN {
     ElectronicTransmissionController2,
     /// TI1 - TANK Information 1.
     TANKInformation1,
-    /// TCO1 - Tachoraph.
-    Tachoraph,
+    /// TCO1 - Tachograph.
+    Tachograph,
     /// EH - ECU History.
     ECUHistory,
     /// FD - Fan Drive.
@@ -97,6 +97,8 @@ pub enum PGN {
     ElectronicEngineController3,
     /// VD - Vehicle Distance.
     VehicleDistance,
+    /// VDHR - High Resolution Vehicle Distance.
+    HighResolutionVehicleDistance,
     /// EC - Engine Configuration.
     EngineConfiguration,
     /// SHUTDOWN - Shutdown.
@@ -215,7 +217,7 @@ impl From<u32> for PGN {
             61_444 => PGN::ElectronicEngineController1,
             61_445 => PGN::ElectronicTransmissionController2,
             65_110 => PGN::TANKInformation1,
-            65_132 => PGN::Tachoraph,
+            65_132 => PGN::Tachograph,
             65_201 => PGN::ECUHistory,
             65_213 => PGN::FanDrive,
             65_214 => PGN::ElectronicEngineController4,
@@ -232,6 +234,7 @@ impl From<u32> for PGN {
             65_244 => PGN::IdleOperation,
             65_247 => PGN::ElectronicEngineController3,
             65_248 => PGN::VehicleDistance,
+            65_217 => PGN::HighResolutionVehicleDistance,
             65_251 => PGN::EngineConfiguration,
             65_252 => PGN::Shutdown,
             65_253 => PGN::EngineHoursRevolutions,
@@ -299,7 +302,7 @@ impl From<PGN> for u32 {
             PGN::ElectronicEngineController2 => 61_443,
             PGN::ElectronicTransmissionController2 => 61_445,
             PGN::TANKInformation1 => 65_110,
-            PGN::Tachoraph => 65_132,
+            PGN::Tachograph => 65_132,
             PGN::ECUHistory => 65_201,
             PGN::FanDrive => 65_213,
             PGN::ElectronicEngineController4 => 65_214,
@@ -316,6 +319,7 @@ impl From<PGN> for u32 {
             PGN::IdleOperation => 65_244,
             PGN::ElectronicEngineController3 => 65_247,
             PGN::VehicleDistance => 65_248,
+            PGN::HighResolutionVehicleDistance => 65_217,
             PGN::EngineConfiguration => 65_251,
             PGN::Shutdown => 65_252,
             PGN::EngineHoursRevolutions => 65_253,

--- a/src/slots.rs
+++ b/src/slots.rs
@@ -590,6 +590,29 @@ pub mod hour_offset {
     }
 }
 
+pub mod id {
+    const RESOLUTION: super::Param = super::Param {
+        scale: 1.0,
+        offset: 0.0,
+        limit_lower: 0.0,
+        limit_upper: 250.0,
+    };
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub fn dec(value: u8) -> Option<u8> {
+        if value == crate::PDU_NOT_AVAILABLE {
+            return None;
+        }
+
+        Some(RESOLUTION.dec(f32::from(value)) as u8)
+    }
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub fn enc(value: Option<u8>) -> u8 {
+        value.map_or(crate::PDU_NOT_AVAILABLE, |v| RESOLUTION.enc(f32::from(v)) as u8)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/slots.rs
+++ b/src/slots.rs
@@ -439,6 +439,40 @@ pub mod liquid_fuel_usage {
     }
 }
 
+// High-resolution distance: SAEds09 (5 m/bit), used in PGN 65217
+pub mod distance5m {
+    const RESOLUTION: super::Param = super::Param {
+        scale: 5.0,
+        offset: 0.0,
+        limit_lower: 0.0,
+        limit_upper: 21_055_406_075.0,
+    };
+
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss
+    )]
+    pub fn dec(value: [u8; 4]) -> Option<u32> {
+        if value == [crate::PDU_NOT_AVAILABLE; 4] {
+            return None;
+        }
+
+        Some(RESOLUTION.dec(u32::from_le_bytes(value) as f32) as u32)
+    }
+
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss
+    )]
+    pub fn enc(value: Option<u32>) -> [u8; 4] {
+        value.map_or([crate::PDU_NOT_AVAILABLE; 4], |v| {
+            (RESOLUTION.enc(v as f32) as u32).to_le_bytes()
+        })
+    }
+}
+
 pub mod distance {
     const RESOLUTION: super::Param = super::Param {
         scale: 0.125,
@@ -460,6 +494,32 @@ pub mod distance {
     pub fn enc(value: Option<u32>) -> [u8; 4] {
         value.map_or([crate::PDU_NOT_AVAILABLE; 4], |v| {
             (RESOLUTION.enc(v as f32) as u32).to_le_bytes()
+        })
+    }
+}
+
+// Linear velocity SAEvl02 (1/256 km/h per bit), used in PGN 65132 bytes 7-8
+pub mod velocity_linear2 {
+    const RESOLUTION: super::Param = super::Param {
+        scale: 1.0 / 256.0,
+        offset: 0.0,
+        limit_lower: 0.0,
+        limit_upper: 250.99609375,
+    };
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub fn dec(value: [u8; 2]) -> Option<u16> {
+        if value == [crate::PDU_NOT_AVAILABLE; 2] {
+            return None;
+        }
+
+        Some(RESOLUTION.dec(f32::from(u16::from_le_bytes(value))) as u16)
+    }
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub fn enc(value: Option<u16>) -> [u8; 2] {
+        value.map_or([crate::PDU_NOT_AVAILABLE; 2], |v| {
+            (RESOLUTION.enc(f32::from(v)) as u16).to_le_bytes()
         })
     }
 }
@@ -486,6 +546,47 @@ pub mod time {
         value.map_or([crate::PDU_NOT_AVAILABLE; 4], |v| {
             (RESOLUTION.enc(v as f32) as u32).to_le_bytes()
         })
+    }
+}
+
+// Offsets for Time/Date local offsets
+pub mod minute_offset {
+    const RESOLUTION: super::Param = super::Param {
+        scale: 1.0,
+        offset: -125.0,
+        limit_lower: -125.0,
+        limit_upper: 125.0,
+    };
+
+    pub fn dec(value: u8) -> Option<i8> {
+        if value == crate::PDU_NOT_AVAILABLE {
+            return None;
+        }
+        Some(RESOLUTION.dec(f32::from(value)) as i8)
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn enc(value: Option<i8>) -> u8 {
+        value.map_or(crate::PDU_NOT_AVAILABLE, |v| RESOLUTION.enc(f32::from(v)) as u8)
+    }
+}
+
+pub mod hour_offset {
+    const RESOLUTION: super::Param = super::Param {
+        scale: 1.0,
+        offset: -125.0,
+        limit_lower: -125.0,
+        limit_upper: 125.0,
+    };
+
+    pub fn dec(value: u8) -> Option<i8> {
+        if value == crate::PDU_NOT_AVAILABLE { return None; }
+        Some(RESOLUTION.dec(f32::from(value)) as i8)
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn enc(value: Option<i8>) -> u8 {
+        value.map_or(crate::PDU_NOT_AVAILABLE, |v| RESOLUTION.enc(f32::from(v)) as u8)
     }
 }
 

--- a/tests/dump_roundtrip.rs
+++ b/tests/dump_roundtrip.rs
@@ -1,0 +1,38 @@
+use j1939::spn::*;
+
+fn hex_to_bytes(s: &str) -> [u8; 8] {
+    let mut bytes = [0u8; 8];
+    for (i, chunk) in s.as_bytes().chunks(2).enumerate().take(8) {
+        let hi = (chunk[0] as char).to_digit(16).unwrap();
+        let lo = (chunk[1] as char).to_digit(16).unwrap();
+        bytes[i] = ((hi << 4) | lo) as u8;
+    }
+    bytes
+}
+
+#[test]
+fn time_date_roundtrip_from_dump() {
+    // 0x18FEE6EE#243412024029837D (PGN 65254 - Time/Date)
+    let data = hex_to_bytes("243412024029837D");
+    let msg = TimeDate::from_pdu(&data);
+    let encoded = msg.to_pdu();
+    assert_eq!(encoded, data);
+}
+
+#[test]
+fn vdhr_roundtrip_zero() {
+    // 0x18FEC1EE#0000000000000000 (PGN 65217 - High Resolution Vehicle Distance)
+    let data = [0u8; 8];
+    let msg = HighResolutionVehicleDistanceMessage::from_pdu(&data);
+    let encoded = msg.to_pdu();
+    assert_eq!(encoded, data);
+}
+
+#[test]
+fn tco1_roundtrip_from_dump() {
+    // 0x0CFE6CEE#00FFFFC500000000 (PGN 65132 - Tachograph)
+    let data = hex_to_bytes("00FFFFC500000000");
+    let msg = TachographMessage::from_pdu(&data);
+    let encoded = msg.to_pdu();
+    assert_eq!(encoded, data);
+}


### PR DESCRIPTION
This PR extends the J1939 library by adding support for additional Parameter Group Numbers (PGNs) and Suspect Parameter Numbers (SPNs). 

I tried to make the changes as minimally invasive as possible and to adapt as closely as possible to the existing program structure.

With these changes, this crate is already being used in my "Komsi2Tacho" project with a real VDO MTCO 1323 speedometer. I also made sure that the generated CAN messages match the CAN frames bit-for-bit as I observed them in the real world between an MTCO 1323 (speedometer) and an MTCO 1324 (tachograph).

**New PGNs and Messages:**
*   **High Resolution Vehicle Distance (VDHR, PGN 65217):** Added `HighResolutionVehicleDistanceMessage` with its associated SPNs (High Resolution Total Vehicle Distance, High Resolution Trip Distance).
*   **Tachograph (TCO1, PGN 65132):** Added `TachographMessage` support.
*   **Reset (PGN 56832):** Added basic PGN mapping for Reset.

**Enhancements for Existing Messages:**
*   **Time/Date (PGN 65254):** Added SPN 1601 (`local_minute_offset`) and SPN 1602 (`local_hour_offset`) to the `TimeDate` struct.
*   **PGN Enum:** Fixed a typo: `Tachoraph` -> `Tachograph`.

**Internal Improvements (Slots & SPNs):**
*   Added new decoding/encoding slots in `src/slots.rs`:
    *   `distance5m`: 5m/bit resolution (SAEds09).
    *   `velocity_linear2`: 1/256 km/h resolution (SAEvl02).
    *   `minute_offset` and `hour_offset`: For local time adjustments.
    *   `id`: For generic 1-byte identifiers.
*   Implemented `Display` and `from_pdu`/`to_pdu` for the new message types in `src/spn.rs`.

**Tooling and Testing:**
*   Updated the `j1939decode` example to support the new PGNs.
*   **Roundtrip Tests:** New integration tests were added in `tests/dump_roundtrip.rs` to verify that messages can be decoded from raw hex dumps and re-encoded back to the exact same byte sequence.
*   **Unit Tests:** Added unit tests in `src/spn.rs` for `AcknowledgmentMessage` and other components to ensure encoding/decoding logic remains robust.
*   Verified that all existing tests continue to pass.
